### PR TITLE
修复bug: bug内容：即使重新设置了侧边栏展开时的宽度，也不会影响原始的动画宽度

### DIFF
--- a/RetractableSidebarWindow/sidebar.cpp
+++ b/RetractableSidebarWindow/sidebar.cpp
@@ -83,6 +83,9 @@ void Sidebar::addItem(QLayoutItem *item)
 void Sidebar::setIncreasedWidth(quint32 increasedWidth)
 {
     this->increasedWidth = increasedWidth;
+	// 展开时增加的宽度改变了，动画的结束位置也要进行改变
+    this->endSize.rwidth() = this->initialSize.rwidth() + increasedWidth;
+    this->endSize.rheight() = this->initialSize.rheight();
 }
 
 void Sidebar::setExpandTime(int ms)


### PR DESCRIPTION
up，我是在B站看到你的 **C++伸缩侧边栏的视频**，觉得很不错，然后前来学习的。

在我使用过程中我发现即使我通过`setIncreasedWidth`设置了新的宽度，然后实际展开时的宽度也是不会变的（还是默认值270），看了一下源码，发现你在构造函数中设置了`endSize`之后，这个值就没有变过了（当然，可能是我太菜，有些地方我也没看太懂）。

按照道理来说，当重新设置了展开时的宽度后，这个`endSize`的值是应该改变的啊，于是我就把他改了，然后运行发现是符合我的目的的，我想这里你是不是忘记更新`endSize`了 ?


![test](https://github.com/COLORREF/QWidget-FancyUI/assets/102635518/6b34bda0-dd99-41b5-a749-809e51310423)


